### PR TITLE
[feat] content 조회, 삭제, 생성 기능 구현

### DIFF
--- a/Api/src/main/java/allchive/server/api/category/service/DeleteCategoryUseCase.java
+++ b/Api/src/main/java/allchive/server/api/category/service/DeleteCategoryUseCase.java
@@ -25,7 +25,8 @@ public class DeleteCategoryUseCase {
         Long userId = SecurityUtil.getCurrentUserId();
         categoryValidator.verifyUser(userId, categoryId);
         categoryDomainService.deleteById(categoryId);
-        Recycle recycle = recycleMapper.toCategoryRecycleEntity(userId, categoryId, RecycleType.CATEGORY);
+        Recycle recycle =
+                recycleMapper.toCategoryRecycleEntity(userId, categoryId, RecycleType.CATEGORY);
         recycleDomainService.save(recycle);
     }
 }

--- a/Api/src/main/java/allchive/server/api/category/service/DeleteCategoryUseCase.java
+++ b/Api/src/main/java/allchive/server/api/category/service/DeleteCategoryUseCase.java
@@ -2,9 +2,13 @@ package allchive.server.api.category.service;
 
 
 import allchive.server.api.config.security.SecurityUtil;
+import allchive.server.api.recycle.model.mapper.RecycleMapper;
 import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.category.service.CategoryDomainService;
 import allchive.server.domain.domains.category.validator.CategoryValidator;
+import allchive.server.domain.domains.recycle.domain.Recycle;
+import allchive.server.domain.domains.recycle.domain.enums.RecycleType;
+import allchive.server.domain.domains.recycle.service.RecycleDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,11 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeleteCategoryUseCase {
     private final CategoryDomainService categoryDomainService;
     private final CategoryValidator categoryValidator;
+    private final RecycleMapper recycleMapper;
+    private final RecycleDomainService recycleDomainService;
 
     @Transactional
     public void execute(Long categoryId) {
         Long userId = SecurityUtil.getCurrentUserId();
         categoryValidator.verifyUser(userId, categoryId);
-        categoryDomainService.deleteCategory(categoryId);
+        categoryDomainService.deleteById(categoryId);
+        Recycle recycle = recycleMapper.toCategoryRecycleEntity(userId, categoryId, RecycleType.CATEGORY);
+        recycleDomainService.save(recycle);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/controller/ContentController.java
+++ b/Api/src/main/java/allchive/server/api/content/controller/ContentController.java
@@ -4,6 +4,7 @@ import allchive.server.api.category.model.dto.request.CreateCategoryRequest;
 import allchive.server.api.content.model.dto.request.CreateContentRequest;
 import allchive.server.api.content.model.dto.response.ContentTagResponse;
 import allchive.server.api.content.service.CreateContentUseCase;
+import allchive.server.api.content.service.DeleteContentUseCase;
 import allchive.server.api.content.service.GetContentUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class ContentController {
     private final CreateContentUseCase createContentUseCase;
     private final GetContentUseCase getContentUseCase;
+    private final DeleteContentUseCase deleteContentUseCase;
 
     @Operation(summary = "컨텐츠를 생성합니다.")
     @PostMapping()
@@ -30,5 +32,11 @@ public class ContentController {
     @GetMapping(value = "/{contentId}")
     public ContentTagResponse createContent(@PathVariable Long contentId) {
         return getContentUseCase.execute(contentId);
+    }
+
+    @Operation(summary = "컨텐츠 내용을 가져옵니다.")
+    @DeleteMapping(value = "/{contentId}")
+    public void deleteContent(@PathVariable Long contentId) {
+        deleteContentUseCase.execute(contentId);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/controller/ContentController.java
+++ b/Api/src/main/java/allchive/server/api/content/controller/ContentController.java
@@ -1,0 +1,34 @@
+package allchive.server.api.content.controller;
+
+import allchive.server.api.category.model.dto.request.CreateCategoryRequest;
+import allchive.server.api.content.model.dto.request.CreateContentRequest;
+import allchive.server.api.content.model.dto.response.ContentTagResponse;
+import allchive.server.api.content.service.CreateContentUseCase;
+import allchive.server.api.content.service.GetContentUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/contents")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "4. [content]")
+public class ContentController {
+    private final CreateContentUseCase createContentUseCase;
+    private final GetContentUseCase getContentUseCase;
+
+    @Operation(summary = "컨텐츠를 생성합니다.")
+    @PostMapping()
+    public void createContent(@RequestBody CreateContentRequest createContentRequest) {
+        createContentUseCase.execute(createContentRequest);
+    }
+
+    @Operation(summary = "컨텐츠 내용을 가져옵니다.")
+    @GetMapping(value = "/{contentId}")
+    public ContentTagResponse createContent(@PathVariable Long contentId) {
+        return getContentUseCase.execute(contentId);
+    }
+}

--- a/Api/src/main/java/allchive/server/api/content/controller/ContentController.java
+++ b/Api/src/main/java/allchive/server/api/content/controller/ContentController.java
@@ -1,6 +1,6 @@
 package allchive.server.api.content.controller;
 
-import allchive.server.api.category.model.dto.request.CreateCategoryRequest;
+
 import allchive.server.api.content.model.dto.request.CreateContentRequest;
 import allchive.server.api.content.model.dto.response.ContentTagResponse;
 import allchive.server.api.content.service.CreateContentUseCase;

--- a/Api/src/main/java/allchive/server/api/content/model/dto/request/CreateContentRequest.java
+++ b/Api/src/main/java/allchive/server/api/content/model/dto/request/CreateContentRequest.java
@@ -1,12 +1,11 @@
 package allchive.server.api.content.model.dto.request;
 
+
 import allchive.server.core.annotation.ValidEnum;
-import allchive.server.domain.domains.category.domain.enums.Subject;
 import allchive.server.domain.domains.content.domain.enums.ContentType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-
 import java.util.List;
+import lombok.Getter;
 
 @Getter
 public class CreateContentRequest {

--- a/Api/src/main/java/allchive/server/api/content/model/dto/request/CreateContentRequest.java
+++ b/Api/src/main/java/allchive/server/api/content/model/dto/request/CreateContentRequest.java
@@ -1,0 +1,34 @@
+package allchive.server.api.content.model.dto.request;
+
+import allchive.server.core.annotation.ValidEnum;
+import allchive.server.domain.domains.category.domain.enums.Subject;
+import allchive.server.domain.domains.content.domain.enums.ContentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CreateContentRequest {
+    @Schema(defaultValue = "image", description = "컨텐츠 타입")
+    @ValidEnum(target = ContentType.class)
+    private ContentType contentType;
+
+    @Schema(defaultValue = "0", description = "카테고리 고유번호")
+    private Long categoryId;
+
+    @Schema(defaultValue = "제목", description = "제목")
+    private String title;
+
+    @Schema(defaultValue = "링크", description = "링크")
+    private String link;
+
+    @Schema(defaultValue = "이미지 url", description = "이미지 url")
+    private String imgUrl;
+
+    @Schema(description = "태그 고유번호 리스트")
+    private List<Long> tagIds;
+
+    @Schema(defaultValue = "메모", description = "메모")
+    private String memo;
+}

--- a/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentResponse.java
+++ b/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentResponse.java
@@ -42,7 +42,9 @@ public class ContentResponse {
             String contentTitle,
             ContentType contentType,
             LocalDateTime contentCreatedAt,
-            String tag,String link, String imgUrl,
+            String tag,
+            String link,
+            String imgUrl,
             Long tagCount) {
         this.contentId = contentId;
         this.contentTitle = contentTitle;

--- a/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentResponse.java
+++ b/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentResponse.java
@@ -1,6 +1,7 @@
 package allchive.server.api.content.model.dto.response;
 
 
+import allchive.server.api.common.util.UrlUtil;
 import allchive.server.core.annotation.DateFormat;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.enums.ContentType;
@@ -62,7 +63,7 @@ public class ContentResponse {
                 .contentTitle(content.getTitle())
                 .contentType(content.getContentType())
                 .link(content.getLinkUrl())
-                .imgUrl(content.getImageUrl())
+                .imgUrl(UrlUtil.toAssetUrl(content.getImageUrl()))
                 .contentCreatedAt(content.getCreatedAt())
                 .tag(tag)
                 .tagCount(tagCount)

--- a/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentTagResponse.java
+++ b/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentTagResponse.java
@@ -1,16 +1,16 @@
 package allchive.server.api.content.model.dto.response;
 
+
 import allchive.server.api.common.util.UrlUtil;
 import allchive.server.core.annotation.DateFormat;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.enums.ContentType;
 import allchive.server.tag.model.dto.response.TagResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 public class ContentTagResponse {
@@ -40,9 +40,14 @@ public class ContentTagResponse {
     private List<TagResponse> tagList;
 
     @Builder
-    private ContentTagResponse(Long contentId, String contentTitle, ContentType contentType,
-                              String link, String imgUrl, LocalDateTime contentCreatedAt,
-                              List<TagResponse> tagList) {
+    private ContentTagResponse(
+            Long contentId,
+            String contentTitle,
+            ContentType contentType,
+            String link,
+            String imgUrl,
+            LocalDateTime contentCreatedAt,
+            List<TagResponse> tagList) {
         this.contentId = contentId;
         this.contentTitle = contentTitle;
         this.contentType = contentType;

--- a/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentTagResponse.java
+++ b/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentTagResponse.java
@@ -1,16 +1,18 @@
 package allchive.server.api.content.model.dto.response;
 
-
 import allchive.server.core.annotation.DateFormat;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.enums.ContentType;
+import allchive.server.tag.model.dto.response.TagResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Getter
-public class ContentResponse {
+public class ContentTagResponse {
     @Schema(description = "컨텐츠 고유번호")
     private Long contentId;
 
@@ -26,44 +28,38 @@ public class ContentResponse {
     @Schema(defaultValue = "컨텐츠 이미지 url", description = "컨텐츠 이미지 url")
     private String imgUrl;
 
-    @Schema(defaultValue = "2023.07.02", description = "컨텐츠 생성일자")
+    @Schema(
+            type = "string",
+            pattern = "yyyy.MM.dd",
+            defaultValue = "2023.07.02",
+            description = "컨텐츠 생성일자")
     @DateFormat
     private LocalDateTime contentCreatedAt;
 
-    @Schema(description = "컨텐츠 태그")
-    private String Tag;
-
-    @Schema(description = "컨텐츠 태그 총 개수")
-    private Long TagCount;
+    private List<TagResponse> tagList;
 
     @Builder
-    private ContentResponse(
-            Long contentId,
-            String contentTitle,
-            ContentType contentType,
-            LocalDateTime contentCreatedAt,
-            String tag,String link, String imgUrl,
-            Long tagCount) {
+    private ContentTagResponse(Long contentId, String contentTitle, ContentType contentType,
+                              String link, String imgUrl, LocalDateTime contentCreatedAt,
+                              List<TagResponse> tagList) {
         this.contentId = contentId;
         this.contentTitle = contentTitle;
         this.contentType = contentType;
-        this.contentCreatedAt = contentCreatedAt;
         this.link = link;
         this.imgUrl = imgUrl;
-        Tag = tag;
-        TagCount = tagCount;
+        this.contentCreatedAt = contentCreatedAt;
+        this.tagList = tagList;
     }
 
-    public static ContentResponse of(Content content, String tag, Long tagCount) {
-        return ContentResponse.builder()
+    public static ContentTagResponse of(Content content, List<TagResponse> tagList) {
+        return ContentTagResponse.builder()
                 .contentId(content.getId())
                 .contentTitle(content.getTitle())
                 .contentType(content.getContentType())
                 .link(content.getLinkUrl())
                 .imgUrl(content.getImageUrl())
                 .contentCreatedAt(content.getCreatedAt())
-                .tag(tag)
-                .tagCount(tagCount)
+                .tagList(tagList)
                 .build();
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentTagResponse.java
+++ b/Api/src/main/java/allchive/server/api/content/model/dto/response/ContentTagResponse.java
@@ -1,5 +1,6 @@
 package allchive.server.api.content.model.dto.response;
 
+import allchive.server.api.common.util.UrlUtil;
 import allchive.server.core.annotation.DateFormat;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.enums.ContentType;
@@ -57,7 +58,7 @@ public class ContentTagResponse {
                 .contentTitle(content.getTitle())
                 .contentType(content.getContentType())
                 .link(content.getLinkUrl())
-                .imgUrl(content.getImageUrl())
+                .imgUrl(UrlUtil.toAssetUrl(content.getImageUrl()))
                 .contentCreatedAt(content.getCreatedAt())
                 .tagList(tagList)
                 .build();

--- a/Api/src/main/java/allchive/server/api/content/model/mapper/ContentMapper.java
+++ b/Api/src/main/java/allchive/server/api/content/model/mapper/ContentMapper.java
@@ -1,11 +1,16 @@
 package allchive.server.api.content.model.mapper;
 
 
+import allchive.server.api.content.model.dto.request.CreateContentRequest;
 import allchive.server.api.content.model.dto.response.ContentResponse;
+import allchive.server.api.content.model.dto.response.ContentTagResponse;
 import allchive.server.core.annotation.Mapper;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
+import allchive.server.tag.model.dto.response.TagResponse;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper
 public class ContentMapper {
@@ -18,5 +23,17 @@ public class ContentMapper {
         ContentTagGroup contentTagGroup = tags.stream().findFirst().orElse(null);
         String tag = contentTagGroup == null ? null : contentTagGroup.getTag().getName();
         return ContentResponse.of(content, tag, (long) tags.size());
+    }
+
+    public Content toEntity(CreateContentRequest request) {
+        return Content.of(request.getCategoryId(),request.getContentType(), request.getImgUrl(),
+                request.getLink(), request.getTitle(), request.getMemo());
+    }
+
+    public ContentTagResponse toContentTagResponse(Content content, List<ContentTagGroup> contentTagGroupList) {
+        List<TagResponse> tagResponseList = contentTagGroupList.stream()
+                .map(contentTagGroup -> TagResponse.from(contentTagGroup.getTag()))
+                .toList();
+        return ContentTagResponse.of(content, tagResponseList);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/model/mapper/ContentMapper.java
+++ b/Api/src/main/java/allchive/server/api/content/model/mapper/ContentMapper.java
@@ -9,9 +9,7 @@ import allchive.server.core.annotation.Mapper;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
 import allchive.server.tag.model.dto.response.TagResponse;
-
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Mapper
 public class ContentMapper {
@@ -27,14 +25,21 @@ public class ContentMapper {
     }
 
     public Content toEntity(CreateContentRequest request) {
-        return Content.of(request.getCategoryId(),request.getContentType(), UrlUtil.convertUrlToKey(request.getImgUrl()),
-                request.getLink(), request.getTitle(), request.getMemo());
+        return Content.of(
+                request.getCategoryId(),
+                request.getContentType(),
+                UrlUtil.convertUrlToKey(request.getImgUrl()),
+                request.getLink(),
+                request.getTitle(),
+                request.getMemo());
     }
 
-    public ContentTagResponse toContentTagResponse(Content content, List<ContentTagGroup> contentTagGroupList) {
-        List<TagResponse> tagResponseList = contentTagGroupList.stream()
-                .map(contentTagGroup -> TagResponse.from(contentTagGroup.getTag()))
-                .toList();
+    public ContentTagResponse toContentTagResponse(
+            Content content, List<ContentTagGroup> contentTagGroupList) {
+        List<TagResponse> tagResponseList =
+                contentTagGroupList.stream()
+                        .map(contentTagGroup -> TagResponse.from(contentTagGroup.getTag()))
+                        .toList();
         return ContentTagResponse.of(content, tagResponseList);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/model/mapper/ContentMapper.java
+++ b/Api/src/main/java/allchive/server/api/content/model/mapper/ContentMapper.java
@@ -1,6 +1,7 @@
 package allchive.server.api.content.model.mapper;
 
 
+import allchive.server.api.common.util.UrlUtil;
 import allchive.server.api.content.model.dto.request.CreateContentRequest;
 import allchive.server.api.content.model.dto.response.ContentResponse;
 import allchive.server.api.content.model.dto.response.ContentTagResponse;
@@ -26,7 +27,7 @@ public class ContentMapper {
     }
 
     public Content toEntity(CreateContentRequest request) {
-        return Content.of(request.getCategoryId(),request.getContentType(), request.getImgUrl(),
+        return Content.of(request.getCategoryId(),request.getContentType(), UrlUtil.convertUrlToKey(request.getImgUrl()),
                 request.getLink(), request.getTitle(), request.getMemo());
     }
 

--- a/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
@@ -1,0 +1,29 @@
+package allchive.server.api.content.service;
+
+import allchive.server.api.config.security.SecurityUtil;
+import allchive.server.api.content.model.dto.request.CreateContentRequest;
+import allchive.server.api.content.model.mapper.ContentMapper;
+import allchive.server.core.annotation.UseCase;
+import allchive.server.domain.domains.category.validator.CategoryValidator;
+import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
+import allchive.server.domain.domains.content.domain.Content;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateContentUseCase {
+    private final CategoryValidator categoryValidator;
+    private final ContentMapper contentMapper;
+    private final ContentAdaptor contentAdaptor;
+
+    // TODO : tag 만들면 연결
+    @Transactional
+    public void execute(CreateContentRequest request) {
+        categoryValidator.validateExistCategory(request.getCategoryId());
+        Long userId = SecurityUtil.getCurrentUserId();
+        categoryValidator.validateCategoryUser(request.getCategoryId(), userId);
+        Content content = contentMapper.toEntity(request);
+        contentAdaptor.save(content);
+    }
+}

--- a/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
@@ -1,11 +1,11 @@
 package allchive.server.api.content.service;
 
+
 import allchive.server.api.config.security.SecurityUtil;
 import allchive.server.api.content.model.dto.request.CreateContentRequest;
 import allchive.server.api.content.model.mapper.ContentMapper;
 import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.category.validator.CategoryValidator;
-import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.service.ContentDomainService;
 import lombok.RequiredArgsConstructor;

--- a/Api/src/main/java/allchive/server/api/content/service/DeleteContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/DeleteContentUseCase.java
@@ -1,24 +1,18 @@
 package allchive.server.api.content.service;
 
+
 import allchive.server.api.config.security.SecurityUtil;
-import allchive.server.api.content.model.dto.response.ContentTagResponse;
-import allchive.server.api.content.model.mapper.ContentMapper;
 import allchive.server.api.recycle.model.mapper.RecycleMapper;
 import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.category.validator.CategoryValidator;
 import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
-import allchive.server.domain.domains.content.adaptor.ContentTagGroupAdaptor;
 import allchive.server.domain.domains.content.domain.Content;
-import allchive.server.domain.domains.content.domain.ContentTagGroup;
-import allchive.server.domain.domains.content.domain.enums.ContentType;
 import allchive.server.domain.domains.content.service.ContentDomainService;
 import allchive.server.domain.domains.recycle.domain.Recycle;
 import allchive.server.domain.domains.recycle.domain.enums.RecycleType;
 import allchive.server.domain.domains.recycle.service.RecycleDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
@@ -29,12 +23,14 @@ public class DeleteContentUseCase {
     private final RecycleMapper recycleMapper;
     private final RecycleDomainService recycleDomainService;
 
+    @Transactional
     public void execute(Long contentId) {
         Long userId = SecurityUtil.getCurrentUserId();
         Content content = contentAdaptor.findById(contentId);
         categoryValidator.validateCategoryUser(content.getCategoryId(), userId);
         contentDomainService.deleteById(contentId);
-        Recycle recycle = recycleMapper.toContentRecycleEntity(userId, contentId, RecycleType.CONTENT);
+        Recycle recycle =
+                recycleMapper.toContentRecycleEntity(userId, contentId, RecycleType.CONTENT);
         recycleDomainService.save(recycle);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/service/DeleteContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/DeleteContentUseCase.java
@@ -3,13 +3,18 @@ package allchive.server.api.content.service;
 import allchive.server.api.config.security.SecurityUtil;
 import allchive.server.api.content.model.dto.response.ContentTagResponse;
 import allchive.server.api.content.model.mapper.ContentMapper;
+import allchive.server.api.recycle.model.mapper.RecycleMapper;
 import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.category.validator.CategoryValidator;
 import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
 import allchive.server.domain.domains.content.adaptor.ContentTagGroupAdaptor;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
+import allchive.server.domain.domains.content.domain.enums.ContentType;
 import allchive.server.domain.domains.content.service.ContentDomainService;
+import allchive.server.domain.domains.recycle.domain.Recycle;
+import allchive.server.domain.domains.recycle.domain.enums.RecycleType;
+import allchive.server.domain.domains.recycle.service.RecycleDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,12 +26,15 @@ public class DeleteContentUseCase {
     private final ContentAdaptor contentAdaptor;
     private final CategoryValidator categoryValidator;
     private final ContentDomainService contentDomainService;
+    private final RecycleMapper recycleMapper;
+    private final RecycleDomainService recycleDomainService;
 
-    // TODO : 휴지통 처리 해야함
     public void execute(Long contentId) {
         Long userId = SecurityUtil.getCurrentUserId();
         Content content = contentAdaptor.findById(contentId);
         categoryValidator.validateCategoryUser(content.getCategoryId(), userId);
         contentDomainService.deleteById(contentId);
+        Recycle recycle = recycleMapper.toContentRecycleEntity(userId, contentId, RecycleType.CONTENT);
+        recycleDomainService.save(recycle);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/service/DeleteContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/DeleteContentUseCase.java
@@ -1,30 +1,32 @@
 package allchive.server.api.content.service;
 
 import allchive.server.api.config.security.SecurityUtil;
-import allchive.server.api.content.model.dto.request.CreateContentRequest;
+import allchive.server.api.content.model.dto.response.ContentTagResponse;
 import allchive.server.api.content.model.mapper.ContentMapper;
 import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.category.validator.CategoryValidator;
 import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
+import allchive.server.domain.domains.content.adaptor.ContentTagGroupAdaptor;
 import allchive.server.domain.domains.content.domain.Content;
+import allchive.server.domain.domains.content.domain.ContentTagGroup;
 import allchive.server.domain.domains.content.service.ContentDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @UseCase
 @RequiredArgsConstructor
-public class CreateContentUseCase {
+public class DeleteContentUseCase {
+    private final ContentAdaptor contentAdaptor;
     private final CategoryValidator categoryValidator;
-    private final ContentMapper contentMapper;
     private final ContentDomainService contentDomainService;
 
-    // TODO : tag 만들면 연결
-    @Transactional
-    public void execute(CreateContentRequest request) {
-        categoryValidator.validateExistCategory(request.getCategoryId());
+    // TODO : 휴지통 처리 해야함
+    public void execute(Long contentId) {
         Long userId = SecurityUtil.getCurrentUserId();
-        categoryValidator.validateCategoryUser(request.getCategoryId(), userId);
-        Content content = contentMapper.toEntity(request);
-        contentDomainService.save(content);
+        Content content = contentAdaptor.findById(contentId);
+        categoryValidator.validateCategoryUser(content.getCategoryId(), userId);
+        contentDomainService.deleteById(contentId);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/service/GetContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/GetContentUseCase.java
@@ -1,7 +1,7 @@
 package allchive.server.api.content.service;
 
+
 import allchive.server.api.config.security.SecurityUtil;
-import allchive.server.api.content.model.dto.request.CreateContentRequest;
 import allchive.server.api.content.model.dto.response.ContentTagResponse;
 import allchive.server.api.content.model.mapper.ContentMapper;
 import allchive.server.core.annotation.UseCase;
@@ -10,10 +10,9 @@ import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
 import allchive.server.domain.domains.content.adaptor.ContentTagGroupAdaptor;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
@@ -28,7 +27,8 @@ public class GetContentUseCase {
         Content content = contentAdaptor.findById(contentId);
         Long userId = SecurityUtil.getCurrentUserId();
         categoryValidator.validatePublicStatus(content.getCategoryId(), userId);
-        List<ContentTagGroup> contentTagGroupList = contentTagGroupAdaptor.findAllByContent(content);
+        List<ContentTagGroup> contentTagGroupList =
+                contentTagGroupAdaptor.findAllByContent(content);
         return contentMapper.toContentTagResponse(content, contentTagGroupList);
     }
 }

--- a/Api/src/main/java/allchive/server/api/content/service/GetContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/GetContentUseCase.java
@@ -1,0 +1,34 @@
+package allchive.server.api.content.service;
+
+import allchive.server.api.config.security.SecurityUtil;
+import allchive.server.api.content.model.dto.request.CreateContentRequest;
+import allchive.server.api.content.model.dto.response.ContentTagResponse;
+import allchive.server.api.content.model.mapper.ContentMapper;
+import allchive.server.core.annotation.UseCase;
+import allchive.server.domain.domains.category.validator.CategoryValidator;
+import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
+import allchive.server.domain.domains.content.adaptor.ContentTagGroupAdaptor;
+import allchive.server.domain.domains.content.domain.Content;
+import allchive.server.domain.domains.content.domain.ContentTagGroup;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetContentUseCase {
+    private final CategoryValidator categoryValidator;
+    private final ContentAdaptor contentAdaptor;
+    private final ContentTagGroupAdaptor contentTagGroupAdaptor;
+    private final ContentMapper contentMapper;
+
+    @Transactional(readOnly = true)
+    public ContentTagResponse execute(Long contentId) {
+        Content content = contentAdaptor.findById(contentId);
+        Long userId = SecurityUtil.getCurrentUserId();
+        categoryValidator.validatePublicStatus(content.getCategoryId(), userId);
+        List<ContentTagGroup> contentTagGroupList = contentTagGroupAdaptor.findAllByContent(content);
+        return contentMapper.toContentTagResponse(content, contentTagGroupList);
+    }
+}

--- a/Api/src/main/java/allchive/server/api/recycle/model/mapper/RecycleMapper.java
+++ b/Api/src/main/java/allchive/server/api/recycle/model/mapper/RecycleMapper.java
@@ -1,0 +1,16 @@
+package allchive.server.api.recycle.model.mapper;
+
+import allchive.server.core.annotation.Mapper;
+import allchive.server.domain.domains.recycle.domain.Recycle;
+import allchive.server.domain.domains.recycle.domain.enums.RecycleType;
+
+@Mapper
+public class RecycleMapper {
+    public Recycle toContentRecycleEntity(Long userId, Long contentId, RecycleType type) {
+        return Recycle.of(type, contentId, null, userId);
+    }
+
+    public Recycle toCategoryRecycleEntity(Long userId, Long categoryId, RecycleType type) {
+        return Recycle.of(type, null, categoryId, userId);
+    }
+}

--- a/Api/src/main/java/allchive/server/api/recycle/model/mapper/RecycleMapper.java
+++ b/Api/src/main/java/allchive/server/api/recycle/model/mapper/RecycleMapper.java
@@ -1,5 +1,6 @@
 package allchive.server.api.recycle.model.mapper;
 
+
 import allchive.server.core.annotation.Mapper;
 import allchive.server.domain.domains.recycle.domain.Recycle;
 import allchive.server.domain.domains.recycle.domain.enums.RecycleType;

--- a/Api/src/main/java/allchive/server/tag/model/dto/response/TagResponse.java
+++ b/Api/src/main/java/allchive/server/tag/model/dto/response/TagResponse.java
@@ -1,5 +1,6 @@
 package allchive.server.tag.model.dto.response;
 
+
 import allchive.server.domain.domains.content.domain.Tag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -20,9 +21,6 @@ public class TagResponse {
     }
 
     public static TagResponse from(Tag tag) {
-        return TagResponse.builder()
-                .tagId(tag.getId())
-                .name(tag.getName())
-                .build();
+        return TagResponse.builder().tagId(tag.getId()).name(tag.getName()).build();
     }
 }

--- a/Api/src/main/java/allchive/server/tag/model/dto/response/TagResponse.java
+++ b/Api/src/main/java/allchive/server/tag/model/dto/response/TagResponse.java
@@ -1,0 +1,28 @@
+package allchive.server.tag.model.dto.response;
+
+import allchive.server.domain.domains.content.domain.Tag;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TagResponse {
+    @Schema(description = "태그 고유번호")
+    private Long tagId;
+
+    @Schema(description = "태그 이름")
+    private String name;
+
+    @Builder
+    private TagResponse(Long tagId, String name) {
+        this.tagId = tagId;
+        this.name = name;
+    }
+
+    public static TagResponse from(Tag tag) {
+        return TagResponse.builder()
+                .tagId(tag.getId())
+                .name(tag.getName())
+                .build();
+    }
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/category/domain/Category.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/category/domain/Category.java
@@ -108,4 +108,8 @@ public class Category extends BaseTimeEntity {
     public void deletePinUserId(Long userId) {
         this.getPinUserId().remove(userId);
     }
+
+    public void delete() {
+        this.deleteStatus = Boolean.TRUE;
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/category/service/CategoryDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/category/service/CategoryDomainService.java
@@ -26,10 +26,6 @@ public class CategoryDomainService {
         categoryAdaptor.save(category);
     }
 
-    public void deleteCategory(Long categoryId) {
-        categoryAdaptor.deleteById(categoryId);
-    }
-
     public void updateScrapCount(Long categoryId, int i) {
         Category category = categoryAdaptor.findById(categoryId);
         category.updateScrapCnt(i);
@@ -44,5 +40,11 @@ public class CategoryDomainService {
             category.deletePinUserId(userId);
         }
         category.updateScrapCnt(pin ? 1 : -1);
+    }
+
+    public void deleteById(Long categoryId) {
+        Category category = categoryAdaptor.findById(categoryId);
+        category.delete();
+        categoryAdaptor.save(category);
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/category/validator/CategoryValidator.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/category/validator/CategoryValidator.java
@@ -42,4 +42,8 @@ public class CategoryValidator {
             throw NotPinnedCategoryException.EXCEPTION;
         }
     }
+
+    public void validateCategoryUser(Long categoryId, Long userId) {
+        categoryAdaptor.findById(categoryId).validateUser(userId);
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentAdaptor.java
@@ -23,7 +23,8 @@ public class ContentAdaptor {
     }
 
     public Content findById(Long contentId) {
-        return contentRepository.findById(contentId)
+        return contentRepository
+                .findById(contentId)
                 .orElseThrow(() -> ContentNotFoundException.EXCEPTION);
     }
 

--- a/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentAdaptor.java
@@ -26,4 +26,8 @@ public class ContentAdaptor {
         return contentRepository.findById(contentId)
                 .orElseThrow(() -> ContentNotFoundException.EXCEPTION);
     }
+
+    public void deleteById(Long contentId) {
+        contentRepository.deleteById(contentId);
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentAdaptor.java
@@ -3,6 +3,7 @@ package allchive.server.domain.domains.content.adaptor;
 
 import allchive.server.core.annotation.Adaptor;
 import allchive.server.domain.domains.content.domain.Content;
+import allchive.server.domain.domains.content.exception.exceptions.ContentNotFoundException;
 import allchive.server.domain.domains.content.repository.ContentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -15,5 +16,14 @@ public class ContentAdaptor {
 
     public Slice<Content> querySliceContentByCategoryId(Long categoryId, Pageable pageable) {
         return contentRepository.querySliceContentByCategoryId(categoryId, pageable);
+    }
+
+    public void save(Content content) {
+        contentRepository.save(content);
+    }
+
+    public Content findById(Long contentId) {
+        return contentRepository.findById(contentId)
+                .orElseThrow(() -> ContentNotFoundException.EXCEPTION);
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentTagGroupAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentTagGroupAdaptor.java
@@ -16,4 +16,8 @@ public class ContentTagGroupAdaptor {
     public List<ContentTagGroup> queryContentIn(List<Content> contentList) {
         return contentTagGroupRepository.queryContentTagGroupIn(contentList);
     }
+
+    public List<ContentTagGroup> findAllByContent(Content content) {
+        return contentTagGroupRepository.findAllByContent(content);
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/domain/Content.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/domain/Content.java
@@ -56,4 +56,8 @@ public class Content extends BaseTimeEntity {
                 .deleteStatus(Boolean.FALSE)
                 .build();
     }
+
+    public void delete() {
+        this.deleteStatus = Boolean.TRUE;
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/domain/Content.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/domain/Content.java
@@ -5,6 +5,7 @@ import allchive.server.domain.common.model.BaseTimeEntity;
 import allchive.server.domain.domains.content.domain.enums.ContentType;
 import javax.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +31,29 @@ public class Content extends BaseTimeEntity {
     private String memo;
 
     private boolean deleteStatus = Boolean.FALSE;
+
+    @Builder
+    private Content(Long categoryId, ContentType contentType, String imageUrl,
+                   String linkUrl, String title, String memo, boolean deleteStatus) {
+        this.categoryId = categoryId;
+        this.contentType = contentType;
+        this.imageUrl = imageUrl;
+        this.linkUrl = linkUrl;
+        this.title = title;
+        this.memo = memo;
+        this.deleteStatus = deleteStatus;
+    }
+
+    public static Content of(Long categoryId, ContentType contentType, String imageUrl,
+                             String linkUrl, String title, String memo) {
+        return Content.builder()
+                .categoryId(categoryId)
+                .contentType(contentType)
+                .imageUrl(imageUrl)
+                .linkUrl(linkUrl)
+                .title(title)
+                .memo(memo)
+                .deleteStatus(Boolean.FALSE)
+                .build();
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/domain/Content.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/domain/Content.java
@@ -33,8 +33,14 @@ public class Content extends BaseTimeEntity {
     private boolean deleteStatus = Boolean.FALSE;
 
     @Builder
-    private Content(Long categoryId, ContentType contentType, String imageUrl,
-                   String linkUrl, String title, String memo, boolean deleteStatus) {
+    private Content(
+            Long categoryId,
+            ContentType contentType,
+            String imageUrl,
+            String linkUrl,
+            String title,
+            String memo,
+            boolean deleteStatus) {
         this.categoryId = categoryId;
         this.contentType = contentType;
         this.imageUrl = imageUrl;
@@ -44,8 +50,13 @@ public class Content extends BaseTimeEntity {
         this.deleteStatus = deleteStatus;
     }
 
-    public static Content of(Long categoryId, ContentType contentType, String imageUrl,
-                             String linkUrl, String title, String memo) {
+    public static Content of(
+            Long categoryId,
+            ContentType contentType,
+            String imageUrl,
+            String linkUrl,
+            String title,
+            String memo) {
         return Content.builder()
                 .categoryId(categoryId)
                 .contentType(contentType)

--- a/Domain/src/main/java/allchive/server/domain/domains/content/exception/ContentErrorCode.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/exception/ContentErrorCode.java
@@ -7,16 +7,19 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static allchive.server.core.consts.AllchiveConst.NOT_FOUND;
+
 @Getter
 @AllArgsConstructor
 public enum ContentErrorCode implements BaseErrorCode {
-    ;
-    private HttpStatus status;
+    CONTENT_NOT_FOUND(NOT_FOUND, "CATEGORY_404_1", "카테고리를 찾을 수 없습니다.");
+
+    private int status;
     private String code;
     private String reason;
 
     @Override
     public ErrorReason getErrorReason() {
-        return ErrorReason.of(status.value(), code, reason);
+        return ErrorReason.of(status, code, reason);
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/exception/ContentErrorCode.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/exception/ContentErrorCode.java
@@ -1,13 +1,11 @@
 package allchive.server.domain.domains.content.exception;
 
+import static allchive.server.core.consts.AllchiveConst.NOT_FOUND;
 
 import allchive.server.core.dto.ErrorReason;
 import allchive.server.core.error.BaseErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
-
-import static allchive.server.core.consts.AllchiveConst.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor

--- a/Domain/src/main/java/allchive/server/domain/domains/content/exception/exceptions/ContentNotFoundException.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/exception/exceptions/ContentNotFoundException.java
@@ -2,7 +2,6 @@ package allchive.server.domain.domains.content.exception.exceptions;
 
 
 import allchive.server.core.error.BaseErrorException;
-import allchive.server.domain.domains.category.exception.CategoryErrorCode;
 import allchive.server.domain.domains.content.exception.ContentErrorCode;
 
 public class ContentNotFoundException extends BaseErrorException {

--- a/Domain/src/main/java/allchive/server/domain/domains/content/exception/exceptions/ContentNotFoundException.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/exception/exceptions/ContentNotFoundException.java
@@ -1,0 +1,15 @@
+package allchive.server.domain.domains.content.exception.exceptions;
+
+
+import allchive.server.core.error.BaseErrorException;
+import allchive.server.domain.domains.category.exception.CategoryErrorCode;
+import allchive.server.domain.domains.content.exception.ContentErrorCode;
+
+public class ContentNotFoundException extends BaseErrorException {
+
+    public static final BaseErrorException EXCEPTION = new ContentNotFoundException();
+
+    private ContentNotFoundException() {
+        super(ContentErrorCode.CONTENT_NOT_FOUND);
+    }
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupRepository.java
@@ -1,8 +1,13 @@
 package allchive.server.domain.domains.content.repository;
 
 
+import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ContentTagGroupRepository
-        extends JpaRepository<ContentTagGroup, Long>, ContentTagGroupCustomRepository {}
+        extends JpaRepository<ContentTagGroup, Long>, ContentTagGroupCustomRepository {
+    List<ContentTagGroup> findAllByContent(Content content);
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupRepository.java
@@ -3,9 +3,8 @@ package allchive.server.domain.domains.content.repository;
 
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContentTagGroupRepository
         extends JpaRepository<ContentTagGroup, Long>, ContentTagGroupCustomRepository {

--- a/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentDomainService.java
@@ -2,6 +2,7 @@ package allchive.server.domain.domains.content.service;
 
 
 import allchive.server.core.annotation.DomainService;
+import allchive.server.domain.domains.category.domain.Category;
 import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
 import allchive.server.domain.domains.content.domain.Content;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,8 @@ public class ContentDomainService {
     }
 
     public void deleteById(Long contentId) {
-        contentAdaptor.deleteById(contentId);
+        Content content = contentAdaptor.findById(contentId);
+        content.delete();
+        save(content);
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentDomainService.java
@@ -1,0 +1,21 @@
+package allchive.server.domain.domains.content.service;
+
+
+import allchive.server.core.annotation.DomainService;
+import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
+import allchive.server.domain.domains.content.domain.Content;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class ContentDomainService {
+    private final ContentAdaptor contentAdaptor;
+
+    public void save(Content content) {
+        contentAdaptor.save(content);
+    }
+
+    public void deleteById(Long contentId) {
+        contentAdaptor.deleteById(contentId);
+    }
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentDomainService.java
@@ -2,7 +2,6 @@ package allchive.server.domain.domains.content.service;
 
 
 import allchive.server.core.annotation.DomainService;
-import allchive.server.domain.domains.category.domain.Category;
 import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
 import allchive.server.domain.domains.content.domain.Content;
 import lombok.RequiredArgsConstructor;

--- a/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/service/ContentService.java
@@ -1,7 +1,0 @@
-package allchive.server.domain.domains.content.service;
-
-
-import allchive.server.core.annotation.DomainService;
-
-@DomainService
-public class ContentService {}

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/adaptor/RecycleAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/adaptor/RecycleAdaptor.java
@@ -2,8 +2,16 @@ package allchive.server.domain.domains.recycle.adaptor;
 
 
 import allchive.server.core.annotation.Adaptor;
+import allchive.server.domain.domains.recycle.domain.Recycle;
+import allchive.server.domain.domains.recycle.repository.RecycleRepository;
 import lombok.RequiredArgsConstructor;
 
 @Adaptor
 @RequiredArgsConstructor
-public class RecycleAdaptor {}
+public class RecycleAdaptor {
+    private final RecycleRepository recycleRepository;
+
+    public void save(Recycle recycle) {
+        recycleRepository.save(recycle);
+    }
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/Recycle.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/Recycle.java
@@ -3,9 +3,15 @@ package allchive.server.domain.domains.recycle.domain;
 
 import allchive.server.domain.common.model.BaseTimeEntity;
 import javax.persistence.*;
+
+import allchive.server.domain.domains.content.domain.enums.ContentType;
+import allchive.server.domain.domains.recycle.domain.enums.RecycleType;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Table(name = "tbl_recycle")
@@ -15,4 +21,32 @@ public class Recycle extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RecycleType recycleType;
+
+    private Long contentId;
+    private Long categoryId;
+    private Long userId;
+    private LocalDateTime deletedAt;
+
+    @Builder
+    private Recycle(RecycleType recycleType, Long contentId, Long categoryId, Long userId, LocalDateTime deletedAt) {
+        this.recycleType = recycleType;
+        this.contentId = contentId;
+        this.categoryId = categoryId;
+        this.userId = userId;
+        this.deletedAt = deletedAt;
+    }
+
+    public static Recycle of(RecycleType recycleType, Long contentId, Long categoryId, Long userId) {
+        return Recycle.builder()
+                .categoryId(categoryId)
+                .contentId(contentId)
+                .recycleType(recycleType)
+                .userId(userId)
+                .deletedAt(LocalDateTime.now())
+                .build();
+    }
+
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/Recycle.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/Recycle.java
@@ -2,16 +2,13 @@ package allchive.server.domain.domains.recycle.domain;
 
 
 import allchive.server.domain.common.model.BaseTimeEntity;
-import javax.persistence.*;
-
-import allchive.server.domain.domains.content.domain.enums.ContentType;
 import allchive.server.domain.domains.recycle.domain.enums.RecycleType;
+import java.time.LocalDateTime;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Table(name = "tbl_recycle")
@@ -31,7 +28,12 @@ public class Recycle extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    private Recycle(RecycleType recycleType, Long contentId, Long categoryId, Long userId, LocalDateTime deletedAt) {
+    private Recycle(
+            RecycleType recycleType,
+            Long contentId,
+            Long categoryId,
+            Long userId,
+            LocalDateTime deletedAt) {
         this.recycleType = recycleType;
         this.contentId = contentId;
         this.categoryId = categoryId;
@@ -39,7 +41,8 @@ public class Recycle extends BaseTimeEntity {
         this.deletedAt = deletedAt;
     }
 
-    public static Recycle of(RecycleType recycleType, Long contentId, Long categoryId, Long userId) {
+    public static Recycle of(
+            RecycleType recycleType, Long contentId, Long categoryId, Long userId) {
         return Recycle.builder()
                 .categoryId(categoryId)
                 .contentId(contentId)
@@ -48,5 +51,4 @@ public class Recycle extends BaseTimeEntity {
                 .deletedAt(LocalDateTime.now())
                 .build();
     }
-
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/enums/RecycleType.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/enums/RecycleType.java
@@ -1,0 +1,26 @@
+package allchive.server.domain.domains.recycle.domain.enums;
+
+import allchive.server.domain.domains.user.domain.enums.OauthProvider;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.stream.Stream;
+@Getter
+@AllArgsConstructor
+public enum RecycleType {
+    CONTENT("content"),
+    CATEGORY("category");
+
+    @JsonValue
+    private String value;
+
+    @JsonCreator
+    public static OauthProvider parsing(String inputValue) {
+        return Stream.of(OauthProvider.values())
+                .filter(category -> category.getValue().equals(inputValue))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/enums/RecycleType.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/domain/enums/RecycleType.java
@@ -1,20 +1,20 @@
 package allchive.server.domain.domains.recycle.domain.enums;
 
+
 import allchive.server.domain.domains.user.domain.enums.OauthProvider;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.stream.Stream;
 @Getter
 @AllArgsConstructor
 public enum RecycleType {
     CONTENT("content"),
     CATEGORY("category");
 
-    @JsonValue
-    private String value;
+    @JsonValue private String value;
 
     @JsonCreator
     public static OauthProvider parsing(String inputValue) {

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/service/RecycleDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/service/RecycleDomainService.java
@@ -2,16 +2,16 @@ package allchive.server.domain.domains.recycle.service;
 
 
 import allchive.server.core.annotation.DomainService;
+import allchive.server.domain.domains.recycle.adaptor.RecycleAdaptor;
 import allchive.server.domain.domains.recycle.domain.Recycle;
-import allchive.server.domain.domains.recycle.repository.RecycleRepository;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
 public class RecycleDomainService {
-    private final RecycleRepository recycleRepository;
+    private final RecycleAdaptor recycleAdaptor;
 
     public void save(Recycle recycle) {
-        recycleRepository.save(recycle);
+        recycleAdaptor.save(recycle);
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/service/RecycleDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/service/RecycleDomainService.java
@@ -1,0 +1,17 @@
+package allchive.server.domain.domains.recycle.service;
+
+
+import allchive.server.core.annotation.DomainService;
+import allchive.server.domain.domains.recycle.domain.Recycle;
+import allchive.server.domain.domains.recycle.repository.RecycleRepository;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class RecycleDomainService {
+    private final RecycleRepository recycleRepository;
+
+    public void save(Recycle recycle) {
+        recycleRepository.save(recycle);
+    }
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/recycle/service/RecycleService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/recycle/service/RecycleService.java
@@ -1,7 +1,0 @@
-package allchive.server.domain.domains.recycle.service;
-
-
-import allchive.server.core.annotation.DomainService;
-
-@DomainService
-public class RecycleService {}


### PR DESCRIPTION
# 💡 PR Summary - content 조회, 삭제, 생성 기능 구현
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->
## 개요
- close #27 

## 작업사항
- content 조회, 삭제, 생성 기능 구현
- content, category 삭제시 recycle에 추가되도록 구현

## 변경로직
- category 삭제 부분, 엔티티 삭제에서 휴지통에 추가로 변경
