### PR TITLE
[feat] 태그 검색 기능 추가 및 validation 추가

### DIFF
--- a/Api/src/main/java/allchive/server/api/search/controller/SearchController.java
+++ b/Api/src/main/java/allchive/server/api/search/controller/SearchController.java
@@ -26,7 +26,7 @@ public class SearchController {
     private final GetLatestSearchListUseCase getLatestSearchListUseCase;
     private final GetRelativeSearchListUseCase getRelativeSearchListUseCase;
     private final DeleteLatestSearchUseCase deleteLatestSearchUseCase;
-    private final RenewalTitleDataUseCase renewalTitleDataUseCase;
+    private final RenewalSearchDataUseCase renewalSearchDataUseCase;
 
     @Operation(summary = "검색어를 검색합니다.")
     @GetMapping
@@ -57,7 +57,7 @@ public class SearchController {
 
     @Operation(summary = "자동 완성 데이터 강제 리뉴얼", deprecated = true)
     @GetMapping(value = "/relation/force")
-    public void forceRenewalTitleData() {
-        renewalTitleDataUseCase.executeForce();
+    public void forceRenewalSearchData() {
+        renewalSearchDataUseCase.executeForce();
     }
 }

--- a/Api/src/main/java/allchive/server/api/search/controller/SearchController.java
+++ b/Api/src/main/java/allchive/server/api/search/controller/SearchController.java
@@ -1,6 +1,7 @@
 package allchive.server.api.search.controller;
 
 
+import allchive.server.api.search.model.dto.request.DeleteLatestSearchRequest;
 import allchive.server.api.search.model.dto.request.SearchRequest;
 import allchive.server.api.search.model.dto.response.SearchListResponse;
 import allchive.server.api.search.model.dto.response.SearchResponse;
@@ -44,9 +45,9 @@ public class SearchController {
     }
 
     @Operation(summary = "최근 검색어를 삭제합니다.")
-    @DeleteMapping(value = "/latest/{latestId}")
-    public void deleteLatestSearch(@PathVariable("latestId") Long latestId) {
-        deleteLatestSearchUseCase.execute(latestId);
+    @DeleteMapping(value = "/latest")
+    public void deleteLatestSearch(@RequestBody DeleteLatestSearchRequest request) {
+        deleteLatestSearchUseCase.execute(request);
     }
 
     @Operation(summary = "검색어 자동 완성")

--- a/Api/src/main/java/allchive/server/api/search/controller/SearchController.java
+++ b/Api/src/main/java/allchive/server/api/search/controller/SearchController.java
@@ -2,7 +2,6 @@ package allchive.server.api.search.controller;
 
 
 import allchive.server.api.search.model.dto.request.DeleteLatestSearchRequest;
-import allchive.server.api.search.model.dto.request.SearchRequest;
 import allchive.server.api.search.model.dto.response.SearchListResponse;
 import allchive.server.api.search.model.dto.response.SearchResponse;
 import allchive.server.api.search.model.dto.response.SearchVoListResponse;

--- a/Api/src/main/java/allchive/server/api/search/model/dto/request/DeleteLatestSearchRequest.java
+++ b/Api/src/main/java/allchive/server/api/search/model/dto/request/DeleteLatestSearchRequest.java
@@ -1,0 +1,12 @@
+package allchive.server.api.search.model.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DeleteLatestSearchRequest {
+    @Schema(description = "삭제할 최근 검색어 고유번호 리스트")
+    private List<Long> ids;
+}

--- a/Api/src/main/java/allchive/server/api/search/model/dto/request/DeleteLatestSearchRequest.java
+++ b/Api/src/main/java/allchive/server/api/search/model/dto/request/DeleteLatestSearchRequest.java
@@ -1,9 +1,9 @@
 package allchive.server.api.search.model.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.Getter;
 
 @Getter
 public class DeleteLatestSearchRequest {

--- a/Api/src/main/java/allchive/server/api/search/service/DeleteLatestSearchUseCase.java
+++ b/Api/src/main/java/allchive/server/api/search/service/DeleteLatestSearchUseCase.java
@@ -2,26 +2,31 @@ package allchive.server.api.search.service;
 
 
 import allchive.server.api.config.security.SecurityUtil;
+import allchive.server.api.search.model.dto.request.DeleteLatestSearchRequest;
 import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.search.adaptor.LatestSearchAdaptor;
+import allchive.server.domain.domains.search.service.LatestSearchDomainService;
 import allchive.server.domain.domains.search.validator.LatestSearchValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
 public class DeleteLatestSearchUseCase {
     private final LatestSearchValidator latestSearchValidator;
-    private final LatestSearchAdaptor latestSearchAdaptor;
+    private final LatestSearchDomainService latestSearchDomainService;
 
     @Transactional
-    public void execute(Long latestSearchId) {
-        Long userId = SecurityUtil.getCurrentUserId();
-        validateExecution(latestSearchId, userId);
-        latestSearchAdaptor.deleteByIdAndUserId(latestSearchId, userId);
+    public void execute(DeleteLatestSearchRequest request) {
+        validateExecution(request.getIds());
+        latestSearchDomainService.deleteAllByIdIn(request.getIds());
     }
 
-    private void validateExecution(Long latestSearchId, Long userId) {
-        latestSearchValidator.validateExistByIdAndUserId(latestSearchId, userId);
+    private void validateExecution(List<Long> ids) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        latestSearchValidator.validateExistByIdIn(ids);
+        latestSearchValidator.verifyUserByIdIn(ids, userId);
     }
 }

--- a/Api/src/main/java/allchive/server/api/search/service/DeleteLatestSearchUseCase.java
+++ b/Api/src/main/java/allchive/server/api/search/service/DeleteLatestSearchUseCase.java
@@ -4,13 +4,11 @@ package allchive.server.api.search.service;
 import allchive.server.api.config.security.SecurityUtil;
 import allchive.server.api.search.model.dto.request.DeleteLatestSearchRequest;
 import allchive.server.core.annotation.UseCase;
-import allchive.server.domain.domains.search.adaptor.LatestSearchAdaptor;
 import allchive.server.domain.domains.search.service.LatestSearchDomainService;
 import allchive.server.domain.domains.search.validator.LatestSearchValidator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor

--- a/Api/src/main/java/allchive/server/api/search/service/GetRelativeSearchListUseCase.java
+++ b/Api/src/main/java/allchive/server/api/search/service/GetRelativeSearchListUseCase.java
@@ -3,7 +3,6 @@ package allchive.server.api.search.service;
 import static allchive.server.core.consts.AllchiveConst.SEARCH_KEY;
 import static jodd.util.StringPool.ASTERISK;
 
-import allchive.server.api.search.model.dto.request.SearchRequest;
 import allchive.server.api.search.model.dto.response.SearchListResponse;
 import allchive.server.core.annotation.UseCase;
 import java.util.ArrayList;

--- a/Api/src/main/java/allchive/server/api/search/service/SearchArchivingUseCase.java
+++ b/Api/src/main/java/allchive/server/api/search/service/SearchArchivingUseCase.java
@@ -21,15 +21,12 @@ import allchive.server.domain.domains.user.domain.Scrap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
-@Slf4j
 @RequiredArgsConstructor
 public class SearchArchivingUseCase {
     private final ArchivingAdaptor archivingAdaptor;
@@ -67,7 +64,6 @@ public class SearchArchivingUseCase {
 
     private Set<Long> getTagArchivingIds(Long userId, String word) {
         List<Tag> tags = tagAdaptor.findAllByUserIdAndName(userId, word);
-        tags.forEach(tag -> log.info(tag.getName()));
         return contentTagGroupAdaptor.queryContentTagGroupByTagInWithContent(tags).stream()
                 .map(contentTagGroup -> contentTagGroup.getContent().getArchivingId())
                 .collect(Collectors.toSet());
@@ -85,14 +81,18 @@ public class SearchArchivingUseCase {
     }
 
     private boolean isExistSearchKeyword(List<LatestSearch> searches, String keyword) {
-        return !searches.stream().filter(search -> search.getKeyword().equals(keyword)).toList().isEmpty();
+        return !searches.stream()
+                .filter(search -> search.getKeyword().equals(keyword))
+                .toList()
+                .isEmpty();
     }
 
     private SliceResponse<ArchivingResponse> getMyArchivings(
             Long userId, String keyword, Pageable pageable, Set<Long> tagArchivingIds) {
         Slice<ArchivingResponse> archivingSlices =
                 archivingAdaptor
-                        .querySliceArchivingByUserIdAndKeywordsOrderByTagArchvingIds(userId, keyword, pageable, tagArchivingIds)
+                        .querySliceArchivingByUserIdAndKeywordsOrderByTagArchvingIds(
+                                userId, keyword, pageable, tagArchivingIds)
                         .map(archiving -> ArchivingResponse.of(archiving, Boolean.FALSE));
         return SliceResponse.of(archivingSlices);
     }

--- a/Api/src/main/java/allchive/server/api/search/service/SearchArchivingUseCase.java
+++ b/Api/src/main/java/allchive/server/api/search/service/SearchArchivingUseCase.java
@@ -10,18 +10,26 @@ import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.archiving.adaptor.ArchivingAdaptor;
 import allchive.server.domain.domains.block.adaptor.BlockAdaptor;
 import allchive.server.domain.domains.block.domain.Block;
+import allchive.server.domain.domains.content.adaptor.ContentTagGroupAdaptor;
+import allchive.server.domain.domains.content.adaptor.TagAdaptor;
+import allchive.server.domain.domains.content.domain.Tag;
 import allchive.server.domain.domains.search.adaptor.LatestSearchAdaptor;
 import allchive.server.domain.domains.search.domain.LatestSearch;
 import allchive.server.domain.domains.search.service.LatestSearchDomainService;
 import allchive.server.domain.domains.user.adaptor.ScrapAdaptor;
 import allchive.server.domain.domains.user.domain.Scrap;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
+@Slf4j
 @RequiredArgsConstructor
 public class SearchArchivingUseCase {
     private final ArchivingAdaptor archivingAdaptor;
@@ -29,29 +37,40 @@ public class SearchArchivingUseCase {
     private final BlockAdaptor blockAdaptor;
     private final LatestSearchAdaptor latestSearchAdaptor;
     private final LatestSearchDomainService latestSearchDomainService;
+    private final TagAdaptor tagAdaptor;
+    private final ContentTagGroupAdaptor contentTagGroupAdaptor;
 
     @Transactional
     public SearchResponse execute(Pageable pageable, ArchivingType type, String word) {
         Long userId = SecurityUtil.getCurrentUserId();
-        SliceResponse<ArchivingResponse> my = null;
-        SliceResponse<ArchivingResponse> community = null;
+        Set<Long> tagArchivingIds = getTagArchivingIds(userId, word);
+        SliceResponse<ArchivingResponse> my;
+        SliceResponse<ArchivingResponse> community;
         renewalLatestSearch(userId, word);
         switch (type) {
             case ALL -> {
-                my = getMyArchivings(userId, word, pageable);
-                community = getCommunityArchivings(userId, word, pageable);
+                my = getMyArchivings(userId, word, pageable, tagArchivingIds);
+                community = getCommunityArchivings(userId, word, pageable, tagArchivingIds);
                 return SearchResponse.forAll(my, community);
             }
             case MY -> {
-                my = getMyArchivings(userId, word, pageable);
+                my = getMyArchivings(userId, word, pageable, tagArchivingIds);
                 return SearchResponse.forMy(my);
             }
             case COMMUNITY -> {
-                community = getCommunityArchivings(userId, word, pageable);
+                community = getCommunityArchivings(userId, word, pageable, tagArchivingIds);
                 return SearchResponse.forCommunity(community);
             }
         }
         return null;
+    }
+
+    private Set<Long> getTagArchivingIds(Long userId, String word) {
+        List<Tag> tags = tagAdaptor.findAllByUserIdAndName(userId, word);
+        tags.forEach(tag -> log.info(tag.getName()));
+        return contentTagGroupAdaptor.queryContentTagGroupByTagInWithContent(tags).stream()
+                .map(contentTagGroup -> contentTagGroup.getContent().getArchivingId())
+                .collect(Collectors.toSet());
     }
 
     private void renewalLatestSearch(Long userId, String keyword) {
@@ -70,24 +89,24 @@ public class SearchArchivingUseCase {
     }
 
     private SliceResponse<ArchivingResponse> getMyArchivings(
-            Long userId, String keyword, Pageable pageable) {
+            Long userId, String keyword, Pageable pageable, Set<Long> tagArchivingIds) {
         Slice<ArchivingResponse> archivingSlices =
                 archivingAdaptor
-                        .querySliceArchivingByUserIdAndKeywords(userId, keyword, pageable)
+                        .querySliceArchivingByUserIdAndKeywordsOrderByTagArchvingIds(userId, keyword, pageable, tagArchivingIds)
                         .map(archiving -> ArchivingResponse.of(archiving, Boolean.FALSE));
         return SliceResponse.of(archivingSlices);
     }
 
     private SliceResponse<ArchivingResponse> getCommunityArchivings(
-            Long userId, String keyword, Pageable pageable) {
+            Long userId, String keyword, Pageable pageable, Set<Long> tagArchivingIds) {
         List<Long> archivingIdList =
                 scrapAdaptor.findAllByUserId(userId).stream().map(Scrap::getArchivingId).toList();
         List<Long> blockList =
                 blockAdaptor.findByBlockFrom(userId).stream().map(Block::getBlockUser).toList();
         Slice<ArchivingResponse> archivingSlices =
                 archivingAdaptor
-                        .querySliceArchivingByKeywordExceptBlock(
-                                archivingIdList, blockList, keyword, pageable)
+                        .querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
+                                archivingIdList, blockList, keyword, pageable, tagArchivingIds)
                         .map(archiving -> ArchivingResponse.of(archiving, Boolean.FALSE));
         return SliceResponse.of(archivingSlices);
     }

--- a/Api/src/main/java/allchive/server/api/search/service/SearchArchivingUseCase.java
+++ b/Api/src/main/java/allchive/server/api/search/service/SearchArchivingUseCase.java
@@ -56,11 +56,17 @@ public class SearchArchivingUseCase {
 
     private void renewalLatestSearch(Long userId, String keyword) {
         List<LatestSearch> searches = latestSearchAdaptor.findAllByUserIdOrderByCreatedAt(userId);
-        if (searches.size() == 5) {
-            latestSearchDomainService.delete(searches.get(0));
+        if (!isExistSearchKeyword(searches, keyword)) {
+            if (searches.size() == 5) {
+                latestSearchDomainService.delete(searches.get(0));
+            }
+            LatestSearch newSearch = LatestSearch.of(keyword, userId);
+            latestSearchDomainService.save(newSearch);
         }
-        LatestSearch newSearch = LatestSearch.of(keyword, userId);
-        latestSearchDomainService.save(newSearch);
+    }
+
+    private boolean isExistSearchKeyword(List<LatestSearch> searches, String keyword) {
+        return !searches.stream().filter(search -> search.getKeyword().equals(keyword)).toList().isEmpty();
     }
 
     private SliceResponse<ArchivingResponse> getMyArchivings(

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/adaptor/ArchivingAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/adaptor/ArchivingAdaptor.java
@@ -9,7 +9,6 @@ import allchive.server.domain.domains.archiving.exception.exceptions.ArchivingNo
 import allchive.server.domain.domains.archiving.repository.ArchivingRepository;
 import java.util.List;
 import java.util.Set;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -82,7 +81,11 @@ public class ArchivingAdaptor {
     }
 
     public Slice<Archiving> querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
-            List<Long> archivingIdList, List<Long> blockList, String keyword, Pageable pageable, Set<Long> tagArchivingIds) {
+            List<Long> archivingIdList,
+            List<Long> blockList,
+            String keyword,
+            Pageable pageable,
+            Set<Long> tagArchivingIds) {
         return archivingRepository.querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
                 archivingIdList, blockList, keyword, pageable, tagArchivingIds);
     }

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/adaptor/ArchivingAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/adaptor/ArchivingAdaptor.java
@@ -8,6 +8,8 @@ import allchive.server.domain.domains.archiving.domain.enums.Category;
 import allchive.server.domain.domains.archiving.exception.exceptions.ArchivingNotFoundException;
 import allchive.server.domain.domains.archiving.repository.ArchivingRepository;
 import java.util.List;
+import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -73,16 +75,16 @@ public class ArchivingAdaptor {
         archivingRepository.deleteAllById(archivingIds);
     }
 
-    public Slice<Archiving> querySliceArchivingByUserIdAndKeywords(
-            Long userId, String keyword, Pageable pageable) {
-        return archivingRepository.querySliceArchivingByUserIdAndKeywords(
-                userId, keyword, pageable);
+    public Slice<Archiving> querySliceArchivingByUserIdAndKeywordsOrderByTagArchvingIds(
+            Long userId, String keyword, Pageable pageable, Set<Long> tagArchivingIds) {
+        return archivingRepository.querySliceArchivingByUserIdAndKeywordsOrderByTagArchvingIds(
+                userId, keyword, pageable, tagArchivingIds);
     }
 
-    public Slice<Archiving> querySliceArchivingByKeywordExceptBlock(
-            List<Long> archivingIdList, List<Long> blockList, String keyword, Pageable pageable) {
-        return archivingRepository.querySliceArchivingByKeywordExceptBlock(
-                archivingIdList, blockList, keyword, pageable);
+    public Slice<Archiving> querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
+            List<Long> archivingIdList, List<Long> blockList, String keyword, Pageable pageable, Set<Long> tagArchivingIds) {
+        return archivingRepository.querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
+                archivingIdList, blockList, keyword, pageable, tagArchivingIds);
     }
 
     public List<Archiving> findAllByPublicStatus(Boolean publicStatus) {

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepository.java
@@ -4,6 +4,8 @@ package allchive.server.domain.domains.archiving.repository;
 import allchive.server.domain.domains.archiving.domain.Archiving;
 import allchive.server.domain.domains.archiving.domain.enums.Category;
 import java.util.List;
+import java.util.Set;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -20,9 +22,9 @@ public interface ArchivingCustomRepository {
 
     boolean queryArchivingExistById(Long archivingId);
 
-    Slice<Archiving> querySliceArchivingByUserIdAndKeywords(
-            Long userId, String keyword, Pageable pageable);
+    Slice<Archiving> querySliceArchivingByUserIdAndKeywordsOrderByTagArchvingIds(
+            Long userId, String keyword, Pageable pageable, Set<Long> tagArchivingIds);
 
-    Slice<Archiving> querySliceArchivingByKeywordExceptBlock(
-            List<Long> archivingIdList, List<Long> blockList, String keyword, Pageable pageable);
+    Slice<Archiving> querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
+            List<Long> archivingIdList, List<Long> blockList, String keyword, Pageable pageable, Set<Long> tagArchivingIds);
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepository.java
@@ -5,7 +5,6 @@ import allchive.server.domain.domains.archiving.domain.Archiving;
 import allchive.server.domain.domains.archiving.domain.enums.Category;
 import java.util.List;
 import java.util.Set;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -26,5 +25,9 @@ public interface ArchivingCustomRepository {
             Long userId, String keyword, Pageable pageable, Set<Long> tagArchivingIds);
 
     Slice<Archiving> querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
-            List<Long> archivingIdList, List<Long> blockList, String keyword, Pageable pageable, Set<Long> tagArchivingIds);
+            List<Long> archivingIdList,
+            List<Long> blockList,
+            String keyword,
+            Pageable pageable,
+            Set<Long> tagArchivingIds);
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepositoryImpl.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepositoryImpl.java
@@ -13,7 +13,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -110,7 +109,11 @@ public class ArchivingCustomRepositoryImpl implements ArchivingCustomRepository 
 
     @Override
     public Slice<Archiving> querySliceArchivingByKeywordExceptBlockOrderByTagArchvingIds(
-            List<Long> archivingIdList, List<Long> blockList, String keyword, Pageable pageable, Set<Long> tagArchivingIds) {
+            List<Long> archivingIdList,
+            List<Long> blockList,
+            String keyword,
+            Pageable pageable,
+            Set<Long> tagArchivingIds) {
         List<Archiving> archivings =
                 queryFactory
                         .select(archiving)
@@ -120,7 +123,11 @@ public class ArchivingCustomRepositoryImpl implements ArchivingCustomRepository 
                                 publicStatusTrue(),
                                 deleteStatusFalse(),
                                 titleContainOrIdIn(keyword, tagArchivingIds))
-                        .orderBy(idIn(tagArchivingIds), scrabListDesc(archivingIdList), scrapCntDesc(), createdAtDesc())
+                        .orderBy(
+                                idIn(tagArchivingIds),
+                                scrabListDesc(archivingIdList),
+                                scrapCntDesc(),
+                                createdAtDesc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();

--- a/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentTagGroupAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/ContentTagGroupAdaptor.java
@@ -41,4 +41,8 @@ public class ContentTagGroupAdaptor {
     public void deleteAllByContent(Content content) {
         contentTagGroupRepository.deleteAllByContent(content);
     }
+
+    public List<ContentTagGroup> queryContentTagGroupByTagInWithContent(List<Tag> tags) {
+        return contentTagGroupRepository.queryContentTagGroupByTagInWithContent(tags);
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/TagAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/TagAdaptor.java
@@ -44,4 +44,8 @@ public class TagAdaptor {
     public void deleteAll(List<Tag> tagList) {
         tagRepository.deleteAll(tagList);
     }
+
+    public List<Tag> findAllByUserIdAndName(Long userId, String word) {
+        return tagRepository.findAllByUserIdAndName(userId, word);
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/TagAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/adaptor/TagAdaptor.java
@@ -48,4 +48,8 @@ public class TagAdaptor {
     public List<Tag> findAllByUserIdAndName(Long userId, String word) {
         return tagRepository.findAllByUserIdAndName(userId, word);
     }
+
+    public List<Tag> findAll() {
+        return tagRepository.findAll();
+    }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepository.java
@@ -3,10 +3,14 @@ package allchive.server.domain.domains.content.repository;
 
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
+import allchive.server.domain.domains.content.domain.Tag;
+
 import java.util.List;
 
 public interface ContentTagGroupCustomRepository {
     public List<ContentTagGroup> queryContentTagGroupByContentIn(List<Content> contentList);
 
     List<ContentTagGroup> queryContentTagGroupByContentWithTag(Content content);
+
+    List<ContentTagGroup> queryContentTagGroupByTagInWithContent(List<Tag> tags);
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepository.java
@@ -4,7 +4,6 @@ package allchive.server.domain.domains.content.repository;
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
 import allchive.server.domain.domains.content.domain.Tag;
-
 import java.util.List;
 
 public interface ContentTagGroupCustomRepository {

--- a/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepositoryImpl.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepositoryImpl.java
@@ -2,9 +2,11 @@ package allchive.server.domain.domains.content.repository;
 
 import static allchive.server.domain.domains.content.domain.QContentTagGroup.contentTagGroup;
 import static allchive.server.domain.domains.content.domain.QTag.tag;
+import static allchive.server.domain.domains.content.domain.QContent.content;
 
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;
+import allchive.server.domain.domains.content.domain.Tag;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -38,12 +40,27 @@ public class ContentTagGroupCustomRepositoryImpl implements ContentTagGroupCusto
                 .fetch();
     }
 
+    @Override
+    public List<ContentTagGroup> queryContentTagGroupByTagInWithContent(List<Tag> tags) {
+        return queryFactory
+                .selectFrom(contentTagGroup)
+                .join(contentTagGroup.content, content)
+                .fetchJoin()
+                .where(tagIn(tags))
+                .orderBy(createdAtDesc())
+                .fetch();
+    }
+
     private BooleanExpression contentIdIn(List<Content> contentList) {
         return contentTagGroup.content.in(contentList);
     }
 
     private BooleanExpression contentEq(Content content) {
         return contentTagGroup.content.eq(content);
+    }
+
+    private BooleanExpression tagIn(List<Tag> tagList) {
+        return contentTagGroup.tag.in(tagList);
     }
 
     private OrderSpecifier<LocalDateTime> createdAtDesc() {

--- a/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepositoryImpl.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/repository/ContentTagGroupCustomRepositoryImpl.java
@@ -1,8 +1,8 @@
 package allchive.server.domain.domains.content.repository;
 
+import static allchive.server.domain.domains.content.domain.QContent.content;
 import static allchive.server.domain.domains.content.domain.QContentTagGroup.contentTagGroup;
 import static allchive.server.domain.domains.content.domain.QTag.tag;
-import static allchive.server.domain.domains.content.domain.QContent.content;
 
 import allchive.server.domain.domains.content.domain.Content;
 import allchive.server.domain.domains.content.domain.ContentTagGroup;

--- a/Domain/src/main/java/allchive/server/domain/domains/content/repository/TagRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/content/repository/TagRepository.java
@@ -9,4 +9,6 @@ public interface TagRepository extends JpaRepository<Tag, Long>, TagCustomReposi
     List<Tag> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
     List<Tag> findAllByUserId(Long userId);
+
+    List<Tag> findAllByUserIdAndName(Long userId, String name);
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/search/adaptor/LatestSearchAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/adaptor/LatestSearchAdaptor.java
@@ -3,7 +3,6 @@ package allchive.server.domain.domains.search.adaptor;
 
 import allchive.server.core.annotation.Adaptor;
 import allchive.server.domain.domains.search.domain.LatestSearch;
-import allchive.server.domain.domains.search.exception.exceptions.LatestSearchNotFoundException;
 import allchive.server.domain.domains.search.repository.LatestSearchRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/Domain/src/main/java/allchive/server/domain/domains/search/adaptor/LatestSearchAdaptor.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/adaptor/LatestSearchAdaptor.java
@@ -29,13 +29,11 @@ public class LatestSearchAdaptor {
         latestSearchRepository.deleteAllByUserId(userId);
     }
 
-    public LatestSearch findByIdAndUserId(Long latestSearchId, Long userId) {
-        return latestSearchRepository
-                .findByIdAndUserId(latestSearchId, userId)
-                .orElseThrow(() -> LatestSearchNotFoundException.EXCEPTION);
+    public List<LatestSearch> findAllByIdIn(List<Long> ids) {
+        return latestSearchRepository.findAllByIdIn(ids);
     }
 
-    public void deleteByIdAndUserId(Long latestSearchId, Long userId) {
-        latestSearchRepository.deleteByIdAndUserId(latestSearchId, userId);
+    public void deleteAllByIdIn(List<Long> ids) {
+        latestSearchRepository.deleteAllByIdIn(ids);
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/search/exception/SearchErrorCode.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/exception/SearchErrorCode.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SearchErrorCode implements BaseErrorCode {
+    NO_AUTHORITY_UPDATE_LATEST_SEARCH(FORBIDDEN, "LATESTSEARCH_403_1", "최근 검색어 수정 권한이 없습니다."),
     LATEST_SEARCH_NOT_FOUND(NOT_FOUND, "LATESTSEARCH_404_1", "최근 검색어를 찾을 수 없습니다.");
     private int status;
     private String code;

--- a/Domain/src/main/java/allchive/server/domain/domains/search/exception/exceptions/NoAuthorityUpdateLatestSearchException.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/exception/exceptions/NoAuthorityUpdateLatestSearchException.java
@@ -1,0 +1,14 @@
+package allchive.server.domain.domains.search.exception.exceptions;
+
+
+import allchive.server.core.error.BaseErrorException;
+import allchive.server.domain.domains.search.exception.SearchErrorCode;
+
+public class NoAuthorityUpdateLatestSearchException extends BaseErrorException {
+
+    public static final BaseErrorException EXCEPTION = new NoAuthorityUpdateLatestSearchException();
+
+    private NoAuthorityUpdateLatestSearchException() {
+        super(SearchErrorCode.NO_AUTHORITY_UPDATE_LATEST_SEARCH);
+    }
+}

--- a/Domain/src/main/java/allchive/server/domain/domains/search/repository/LatestSearchRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/repository/LatestSearchRepository.java
@@ -11,7 +11,7 @@ public interface LatestSearchRepository extends JpaRepository<LatestSearch, Long
 
     void deleteAllByUserId(Long userId);
 
-    Optional<LatestSearch> findByIdAndUserId(Long latestSearchId, Long userId);
+    List<LatestSearch> findAllByIdIn(List<Long> ids);
 
-    void deleteByIdAndUserId(Long latestSearchId, Long userId);
+    void deleteAllByIdIn(List<Long> ids);
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/search/repository/LatestSearchRepository.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/repository/LatestSearchRepository.java
@@ -3,7 +3,6 @@ package allchive.server.domain.domains.search.repository;
 
 import allchive.server.domain.domains.search.domain.LatestSearch;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LatestSearchRepository extends JpaRepository<LatestSearch, Long> {

--- a/Domain/src/main/java/allchive/server/domain/domains/search/service/LatestSearchDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/service/LatestSearchDomainService.java
@@ -4,9 +4,8 @@ package allchive.server.domain.domains.search.service;
 import allchive.server.core.annotation.DomainService;
 import allchive.server.domain.domains.search.adaptor.LatestSearchAdaptor;
 import allchive.server.domain.domains.search.domain.LatestSearch;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor

--- a/Domain/src/main/java/allchive/server/domain/domains/search/service/LatestSearchDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/service/LatestSearchDomainService.java
@@ -6,6 +6,8 @@ import allchive.server.domain.domains.search.adaptor.LatestSearchAdaptor;
 import allchive.server.domain.domains.search.domain.LatestSearch;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @DomainService
 @RequiredArgsConstructor
 public class LatestSearchDomainService {
@@ -21,5 +23,9 @@ public class LatestSearchDomainService {
 
     public void deleteAllByUserId(Long userId) {
         latestSearchAdaptor.deleteAllByUserId(userId);
+    }
+
+    public void deleteAllByIdIn(List<Long> ids) {
+        latestSearchAdaptor.deleteAllByIdIn(ids);
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/search/validator/LatestSearchValidator.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/validator/LatestSearchValidator.java
@@ -6,9 +6,8 @@ import allchive.server.domain.domains.search.adaptor.LatestSearchAdaptor;
 import allchive.server.domain.domains.search.domain.LatestSearch;
 import allchive.server.domain.domains.search.exception.exceptions.LatestSearchNotFoundException;
 import allchive.server.domain.domains.search.exception.exceptions.NoAuthorityUpdateLatestSearchException;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Validator
 @RequiredArgsConstructor
@@ -24,10 +23,11 @@ public class LatestSearchValidator {
 
     public void verifyUserByIdIn(List<Long> ids, Long userId) {
         List<LatestSearch> searches = latestSearchAdaptor.findAllByIdIn(ids);
-        searches.forEach(search -> {
-            if (!search.getUserId().equals(userId)) {
-                throw NoAuthorityUpdateLatestSearchException.EXCEPTION;
-            }
-        });
+        searches.forEach(
+                search -> {
+                    if (!search.getUserId().equals(userId)) {
+                        throw NoAuthorityUpdateLatestSearchException.EXCEPTION;
+                    }
+                });
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/search/validator/LatestSearchValidator.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/search/validator/LatestSearchValidator.java
@@ -3,14 +3,31 @@ package allchive.server.domain.domains.search.validator;
 
 import allchive.server.core.annotation.Validator;
 import allchive.server.domain.domains.search.adaptor.LatestSearchAdaptor;
+import allchive.server.domain.domains.search.domain.LatestSearch;
+import allchive.server.domain.domains.search.exception.exceptions.LatestSearchNotFoundException;
+import allchive.server.domain.domains.search.exception.exceptions.NoAuthorityUpdateLatestSearchException;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @Validator
 @RequiredArgsConstructor
 public class LatestSearchValidator {
     private final LatestSearchAdaptor latestSearchAdaptor;
 
-    public void validateExistByIdAndUserId(Long latestSearchId, Long userId) {
-        latestSearchAdaptor.findByIdAndUserId(latestSearchId, userId);
+    public void validateExistByIdIn(List<Long> ids) {
+        List<LatestSearch> searches = latestSearchAdaptor.findAllByIdIn(ids);
+        if (searches.size() != ids.size()) {
+            throw LatestSearchNotFoundException.EXCEPTION;
+        }
+    }
+
+    public void verifyUserByIdIn(List<Long> ids, Long userId) {
+        List<LatestSearch> searches = latestSearchAdaptor.findAllByIdIn(ids);
+        searches.forEach(search -> {
+            if (!search.getUserId().equals(userId)) {
+                throw NoAuthorityUpdateLatestSearchException.EXCEPTION;
+            }
+        });
     }
 }


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->태그 검색 기능 추가 및 validation 추가
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->
## 개요
- close #63

## 작업사항
- 검색하기 최근 검색어 중복 판별 로직 추가
- 최근 검색어 다중 삭제 가능하도록 변경
- 태그도 검색할 수 있도록 변경

## 변경로직
- 최근 검색어 삭제 param -> body로 list 받아서 삭제하도록 수정
- 태그 명 검색 -> content 찾아서 archiving id list 구하기 -> list 안에 있는 것부터 소팅
- 태그 명도 레디스 검색 데이터에 포함
