### PR TITLE
[fix] 컨텐츠 수정시 아카이빙 count 개수 안변함

### DIFF
--- a/Api/src/main/java/allchive/server/api/archiving/service/UpdateArchivingScrapUseCase.java
+++ b/Api/src/main/java/allchive/server/api/archiving/service/UpdateArchivingScrapUseCase.java
@@ -13,6 +13,9 @@ import allchive.server.domain.domains.user.validator.ScrapValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import static allchive.server.core.consts.AllchiveConst.MINUS_ONE;
+import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
+
 @UseCase
 @RequiredArgsConstructor
 public class UpdateArchivingScrapUseCase {
@@ -29,11 +32,11 @@ public class UpdateArchivingScrapUseCase {
         User user = userAdaptor.findById(userId);
         if (cancel) {
             scrapDomainService.deleteScrapByUserAndArchivingId(user, archivingId);
-            archivingDomainService.updateScrapCount(archivingId, -1);
+            archivingDomainService.updateScrapCount(archivingId, MINUS_ONE);
         } else {
             Scrap scrap = Scrap.of(user, archivingId);
             scrapDomainService.save(scrap);
-            archivingDomainService.updateScrapCount(archivingId, 1);
+            archivingDomainService.updateScrapCount(archivingId, PLUS_ONE);
         }
     }
 

--- a/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
@@ -1,5 +1,6 @@
 package allchive.server.api.content.service;
 
+import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
 
 import allchive.server.api.config.security.SecurityUtil;
 import allchive.server.api.content.model.dto.request.CreateContentRequest;
@@ -18,8 +19,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
-import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
-
 @UseCase
 @RequiredArgsConstructor
 public class CreateContentUseCase {
@@ -37,7 +36,8 @@ public class CreateContentUseCase {
         Content content = contentMapper.toEntity(request);
         createContentTagGroup(content, request.getTagIds());
         contentDomainService.save(content);
-        archivingDomainService.updateContentCnt(request.getArchivingId(), request.getContentType(), PLUS_ONE);
+        archivingDomainService.updateContentCnt(
+                request.getArchivingId(), request.getContentType(), PLUS_ONE);
     }
 
     private void validateExecution(CreateContentRequest request) {

--- a/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/CreateContentUseCase.java
@@ -18,6 +18,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
+
 @UseCase
 @RequiredArgsConstructor
 public class CreateContentUseCase {
@@ -35,7 +37,7 @@ public class CreateContentUseCase {
         Content content = contentMapper.toEntity(request);
         createContentTagGroup(content, request.getTagIds());
         contentDomainService.save(content);
-        archivingDomainService.updateContentCnt(request.getArchivingId(), request.getContentType());
+        archivingDomainService.updateContentCnt(request.getArchivingId(), request.getContentType(), PLUS_ONE);
     }
 
     private void validateExecution(CreateContentRequest request) {

--- a/Api/src/main/java/allchive/server/api/content/service/UpdateContentUseCase.java
+++ b/Api/src/main/java/allchive/server/api/content/service/UpdateContentUseCase.java
@@ -1,5 +1,7 @@
 package allchive.server.api.content.service;
 
+import static allchive.server.core.consts.AllchiveConst.MINUS_ONE;
+import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
 
 import allchive.server.api.common.util.UrlUtil;
 import allchive.server.api.config.security.SecurityUtil;
@@ -7,7 +9,6 @@ import allchive.server.api.content.model.dto.request.UpdateContentRequest;
 import allchive.server.api.content.model.mapper.ContentMapper;
 import allchive.server.core.annotation.UseCase;
 import allchive.server.domain.domains.archiving.adaptor.ArchivingAdaptor;
-import allchive.server.domain.domains.archiving.domain.Archiving;
 import allchive.server.domain.domains.archiving.service.ArchivingDomainService;
 import allchive.server.domain.domains.content.adaptor.ContentAdaptor;
 import allchive.server.domain.domains.content.adaptor.TagAdaptor;
@@ -22,9 +23,6 @@ import allchive.server.domain.domains.content.validator.TagValidator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-
-import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
-import static allchive.server.core.consts.AllchiveConst.MINUS_ONE;
 
 @UseCase
 @RequiredArgsConstructor
@@ -57,7 +55,8 @@ public class UpdateContentUseCase {
     private void updateArchiving(Long contentId, Long newArchivingId, ContentType contentType) {
         Content content = contentAdaptor.findById(contentId);
         if (!content.getArchivingId().equals(newArchivingId)) {
-            archivingDomainService.updateContentCnt(content.getArchivingId(), content.getContentType(), MINUS_ONE);
+            archivingDomainService.updateContentCnt(
+                    content.getArchivingId(), content.getContentType(), MINUS_ONE);
             archivingDomainService.updateContentCnt(newArchivingId, contentType, PLUS_ONE);
         }
     }

--- a/Api/src/main/java/allchive/server/api/user/model/mapper/UserMapper.java
+++ b/Api/src/main/java/allchive/server/api/user/model/mapper/UserMapper.java
@@ -7,6 +7,9 @@ import allchive.server.domain.domains.archiving.domain.Archiving;
 import allchive.server.domain.domains.user.domain.User;
 import java.util.List;
 
+import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
+import static allchive.server.core.consts.AllchiveConst.ZERO;
+
 @Mapper
 public class UserMapper {
     public GetUserProfileResponse toGetUserProfileResponse(
@@ -15,7 +18,7 @@ public class UserMapper {
         for (Archiving archiving : archivingList) {
             linkCount += archiving.getLinkCnt();
             imgCount += archiving.getImgCnt();
-            publicArchivingCount += archiving.getPublicStatus() ? 1 : 0;
+            publicArchivingCount += archiving.getPublicStatus() ? PLUS_ONE : ZERO;
         }
         return GetUserProfileResponse.of(
                 user, linkCount, imgCount, publicArchivingCount, archivingList.size());

--- a/Core/src/main/java/allchive/server/core/consts/AllchiveConst.java
+++ b/Core/src/main/java/allchive/server/core/consts/AllchiveConst.java
@@ -40,4 +40,7 @@ public class AllchiveConst {
 
     public static final String SEARCH_KEY = "ARCHIVING_TITLE";
     public static final String ASTERISK = "*";
+
+    public static final int PLUS_ONE = 1;
+    public static final int MINUS_ONE = -1;
 }

--- a/Core/src/main/java/allchive/server/core/consts/AllchiveConst.java
+++ b/Core/src/main/java/allchive/server/core/consts/AllchiveConst.java
@@ -43,4 +43,5 @@ public class AllchiveConst {
 
     public static final int PLUS_ONE = 1;
     public static final int MINUS_ONE = -1;
+    public static final int ZERO = 0;
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepositoryImpl.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/repository/ArchivingCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package allchive.server.domain.domains.archiving.repository;
 
+import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
 import static allchive.server.domain.domains.archiving.domain.QArchiving.archiving;
 
 import allchive.server.domain.common.util.SliceUtil;
@@ -38,7 +39,7 @@ public class ArchivingCustomRepositoryImpl implements ArchivingCustomRepository 
                                 deleteStatusFalse())
                         .orderBy(scrabListDesc(archivingIdList), scrapCntDesc(), createdAtDesc())
                         .offset(pageable.getOffset())
-                        .limit(pageable.getPageSize() + 1)
+                        .limit(pageable.getPageSize() + PLUS_ONE)
                         .fetch();
         return SliceUtil.toSlice(archivings, pageable);
     }
@@ -53,7 +54,7 @@ public class ArchivingCustomRepositoryImpl implements ArchivingCustomRepository 
                         .where(userIdEq(userId), categoryEq(category), deleteStatusFalse())
                         .orderBy(pinDesc(userId), scrapCntDesc(), createdAtDesc())
                         .offset(pageable.getOffset())
-                        .limit(pageable.getPageSize() + 1)
+                        .limit(pageable.getPageSize() + PLUS_ONE)
                         .fetch();
         return SliceUtil.toSlice(archivings, pageable);
     }
@@ -72,7 +73,7 @@ public class ArchivingCustomRepositoryImpl implements ArchivingCustomRepository 
                                 deleteStatusFalse())
                         .orderBy(scrapCntDesc(), createdAtDesc())
                         .offset(pageable.getOffset())
-                        .limit(pageable.getPageSize() + 1)
+                        .limit(pageable.getPageSize() + PLUS_ONE)
                         .fetch();
         return SliceUtil.toSlice(archivings, pageable);
     }
@@ -102,7 +103,7 @@ public class ArchivingCustomRepositoryImpl implements ArchivingCustomRepository 
                         .where(userIdEq(userId), titleContainOrIdIn(keyword, tagArchivingIds))
                         .orderBy(idIn(tagArchivingIds), createdAtDesc())
                         .offset(pageable.getOffset())
-                        .limit(pageable.getPageSize() + 1)
+                        .limit(pageable.getPageSize() + PLUS_ONE)
                         .fetch();
         return SliceUtil.toSlice(archivings, pageable);
     }
@@ -129,7 +130,7 @@ public class ArchivingCustomRepositoryImpl implements ArchivingCustomRepository 
                                 scrapCntDesc(),
                                 createdAtDesc())
                         .offset(pageable.getOffset())
-                        .limit(pageable.getPageSize() + 1)
+                        .limit(pageable.getPageSize() + PLUS_ONE)
                         .fetch();
         return SliceUtil.toSlice(archivings, pageable);
     }

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/service/ArchivingDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/service/ArchivingDomainService.java
@@ -60,12 +60,12 @@ public class ArchivingDomainService {
         archivingAdaptor.deleteAllById(archivingIds);
     }
 
-    public void updateContentCnt(Long archivingId, ContentType contentType) {
+    public void updateContentCnt(Long archivingId, ContentType contentType, int i) {
         Archiving archiving = archivingAdaptor.findById(archivingId);
         if (contentType.equals(ContentType.IMAGE)) {
-            archiving.updateImgCnt(1);
+            archiving.updateImgCnt(i);
         } else {
-            archiving.updateLinkCnt(1);
+            archiving.updateLinkCnt(i);
         }
     }
 }

--- a/Domain/src/main/java/allchive/server/domain/domains/archiving/service/ArchivingDomainService.java
+++ b/Domain/src/main/java/allchive/server/domain/domains/archiving/service/ArchivingDomainService.java
@@ -9,6 +9,9 @@ import allchive.server.domain.domains.content.domain.enums.ContentType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
+import static allchive.server.core.consts.AllchiveConst.MINUS_ONE;
+import static allchive.server.core.consts.AllchiveConst.PLUS_ONE;
+
 @DomainService
 @RequiredArgsConstructor
 public class ArchivingDomainService {
@@ -41,7 +44,7 @@ public class ArchivingDomainService {
         } else {
             archiving.deletePinUserId(userId);
         }
-        archiving.updateScrapCnt(pin ? 1 : -1);
+        archiving.updateScrapCnt(pin ? PLUS_ONE : MINUS_ONE);
     }
 
     public void softDeleteById(Long archivingId) {


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->컨텐츠 수정시 아카이빙 count 개수 안변함
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->
## 개요
- close #90

## 작업사항
- 컨텐츠 수정 부분에 아카이빙 count 개수 변경 로직 추가

## 변경로직
- 컨텐츠 수정 부분에 아카이빙 count 개수 변경 로직 추가
- 1, -1, 0 const로 대체
